### PR TITLE
add proxy generators

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="LINE_SEPARATOR" value="&#10;" />
-    <option name="ENABLE_SECOND_REFORMAT" value="true" />
     <PHPCodeStyleSettings>
       <option name="BLANK_LINES_BETWEEN_IMPORTS" value="1" />
       <option name="GROUP_USE_WRAP" value="1" />

--- a/.idea/durable-php.iml
+++ b/.idea/durable-php.iml
@@ -2,6 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Bottledcode\DurablePhp\" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Bottledcode\DurablePhp\Tests\" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
@@ -94,6 +95,8 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/ta-tikoma/phpunit-architecture-test" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/hamcrest/hamcrest-php" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/mockery/mockery" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/psr/clock" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/.idea/durable-php.iml
+++ b/.idea/durable-php.iml
@@ -2,7 +2,6 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="Bottledcode\DurablePhp\" />
       <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Bottledcode\DurablePhp\Tests\" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
@@ -95,6 +94,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/ta-tikoma/phpunit-architecture-test" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/clock" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -115,6 +115,8 @@
       <path value="$PROJECT_DIR$/vendor/sebastian/global-state" />
       <path value="$PROJECT_DIR$/vendor/sebastian/object-enumerator" />
       <path value="$PROJECT_DIR$/vendor/psr/clock" />
+      <path value="$PROJECT_DIR$/vendor/hamcrest/hamcrest-php" />
+      <path value="$PROJECT_DIR$/vendor/mockery/mockery" />
     </include_path>
   </component>
   <component name="PhpInterpreters">

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -114,11 +114,12 @@
       <path value="$PROJECT_DIR$/vendor/sebastian/complexity" />
       <path value="$PROJECT_DIR$/vendor/sebastian/global-state" />
       <path value="$PROJECT_DIR$/vendor/sebastian/object-enumerator" />
+      <path value="$PROJECT_DIR$/vendor/psr/clock" />
     </include_path>
   </component>
   <component name="PhpInterpreters">
     <interpreters>
-      <interpreter id="6620eadc-90de-415d-8414-bcc8e7cde4eb" name="local:cli" home="docker://DATA" false="false" debugger_id="php.debugger.XDebug">
+      <interpreter id="6620eadc-90de-415d-8414-bcc8e7cde4eb" name="local:cli" home="docker://DATA" auto="false" debugger_id="php.debugger.XDebug">
         <remote_data INTERPRETER_PATH="php" HELPERS_PATH="/opt/.phpstorm_helpers" VALID="true" RUN_AS_ROOT_VIA_SUDO="false" DOCKER_ACCOUNT_NAME="Docker" DOCKER_IMAGE_NAME="local:cli" DOCKER_REMOTE_PROJECT_PATH="/opt/project" />
       </interpreter>
     </interpreters>

--- a/.idea/phpspec.xml
+++ b/.idea/phpspec.xml
@@ -71,6 +71,9 @@
       <PhpSpecSuiteConfiguration>
         <option name="myPath" value="$PROJECT_DIR$" />
       </PhpSpecSuiteConfiguration>
+      <PhpSpecSuiteConfiguration>
+        <option name="myPath" value="$PROJECT_DIR$" />
+      </PhpSpecSuiteConfiguration>
     </suites>
   </component>
 </project>

--- a/.idea/phpspec.xml
+++ b/.idea/phpspec.xml
@@ -74,6 +74,9 @@
       <PhpSpecSuiteConfiguration>
         <option name="myPath" value="$PROJECT_DIR$" />
       </PhpSpecSuiteConfiguration>
+      <PhpSpecSuiteConfiguration>
+        <option name="myPath" value="$PROJECT_DIR$" />
+      </PhpSpecSuiteConfiguration>
     </suites>
   </component>
 </project>

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
     "squizlabs/php_codesniffer": "^3.7",
-    "pestphp/pest": "^2.8"
+    "pestphp/pest": "^2.8",
+    "mockery/mockery": "^1.6"
   },
   "config": {
     "allow-plugins": {

--- a/src/Proxy/ClientProxy.php
+++ b/src/Proxy/ClientProxy.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Bottledcode\DurablePhp\Proxy;
+
+class ClientProxy extends Generator
+{
+    protected function pureMethod(\ReflectionMethod $method): string
+    {
+        $name = $method->getName();
+        $params = $method->getParameters();
+        $params = array_map(
+            function (\ReflectionParameter $param) {
+                $type = $param->getType();
+                if ($type !== null) {
+                    $type = $this->getTypes($type);
+                }
+
+                return "$type \${$param->getName()}";
+            },
+            $params
+        );
+        $params = implode(', ', $params);
+        $return = $method->getReturnType();
+        $return = $return ? ": {$this->getTypes($return)}" : '';
+
+        return <<<EOT
+public function $name($params)$return {
+    return \$this->source->$name(...func_get_args());
+}
+EOT;
+    }
+
+    protected function getName(\ReflectionClass $class): string
+    {
+        return "__ClientProxy_{$class->getShortName()}";
+    }
+
+    protected function impureSignal(\ReflectionMethod $method): string
+    {
+        return $this->impureCall($method);
+    }
+
+    protected function impureCall(\ReflectionMethod $method): string
+    {
+        $name = $method->getName();
+        $params = $method->getParameters();
+        $params = array_map(
+            function (\ReflectionParameter $param) {
+                $type = $param->getType();
+                if ($type !== null) {
+                    $type = $this->getTypes($type);
+                }
+
+                return "$type \${$param->getName()}";
+            },
+            $params
+        );
+        $params = implode(', ', $params);
+        $return = $method->getReturnType();
+        $return = $return ? ": {$this->getTypes($return)}" : '';
+
+        return <<<EOT
+public function $name($params)$return {
+    throw new Bottledcode\DurablePhp\Proxy\ImpureException();
+}
+EOT;
+    }
+
+    protected function preamble(\ReflectionClass $class): string
+    {
+        return <<<EOT
+public function __construct(private mixed \$source) {}
+EOT;
+    }
+}

--- a/src/Proxy/Generator.php
+++ b/src/Proxy/Generator.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Bottledcode\DurablePhp\Proxy;
+
+use ReflectionUnionType;
+
+abstract class Generator
+{
+    public function generate(string $interface): string
+    {
+        $reflection = new \ReflectionClass($interface);
+        $methods = $reflection->getMethods();
+        $namespace = $reflection->getNamespaceName();
+        $className = $reflection->getShortName();
+        $methods = array_map(
+            function (\ReflectionMethod $method) {
+                if ($method->getAttributes(Pure::class)) {
+                    return $this->pureMethod($method);
+                }
+
+                if ($method->getAttributes(\JetBrains\PhpStorm\Pure::class)) {
+                    return $this->pureMethod($method);
+                }
+
+                $return = $method->getReturnType();
+                if (($return instanceof \ReflectionNamedType) && $return->getName() === 'void') {
+                    return $this->impureSignal($method);
+                }
+
+                return $this->impureCall($method);
+            },
+            $methods
+        );
+        $methods = implode("\n", $methods);
+
+        return <<<EOT
+<?php
+namespace {$namespace};
+
+class {$this->getName($reflection)} implements {$className} {
+  {$this->preamble()}
+  $methods
+}
+EOT;
+    }
+
+    abstract protected function pureMethod(\ReflectionMethod $method): string;
+
+    abstract protected function getName(\ReflectionClass $class): string;
+
+    abstract protected function impureSignal(\ReflectionMethod $method): string;
+
+    abstract protected function impureCall(\ReflectionMethod $method): string;
+
+    abstract protected function preamble(\ReflectionClass $class): string;
+
+    protected function getTypes(\ReflectionNamedType|ReflectionUnionType|\ReflectionIntersectionType|null $type): string
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            return $type->getName();
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            return implode('|', array_map($this->getTypes(...), $type->getTypes()));
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return implode('&', array_map($this->getTypes(...), $type->getTypes()));
+        }
+
+        return '';
+    }
+}

--- a/src/Proxy/ImpureException.php
+++ b/src/Proxy/ImpureException.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Bottledcode\DurablePhp\Proxy;
+
+use Throwable;
+
+class ImpureException extends \DomainException
+{
+    public function __construct(
+        string $message = "Attempted to call an impure snapshot method. Mark the method Pure.",
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Proxy/OrchestratorProxy.php
+++ b/src/Proxy/OrchestratorProxy.php
@@ -90,7 +90,7 @@ EOT;
     protected function preamble(\ReflectionClass $class): string
     {
         return <<<EOT
-public function __construct(private OrchestrationContext \$context, private EntityId \$id) {}
+public function __construct(private Bottledcode\DurablePhp\OrchestrationContextInterface \$context, private Bottledcode\DurablePhp\State\EntityId \$id) {}
 EOT;
     }
 }

--- a/src/Proxy/OrchestratorProxy.php
+++ b/src/Proxy/OrchestratorProxy.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Bottledcode\DurablePhp\Proxy;
+
+class OrchestratorProxy extends Generator
+{
+    protected function pureMethod(\ReflectionMethod $method): string
+    {
+        return $this->impureCall($method);
+    }
+
+    protected function impureCall(\ReflectionMethod $method): string
+    {
+        $name = $method->getName();
+        $params = $method->getParameters();
+        $params = array_map(
+            function (\ReflectionParameter $param) {
+                $type = $param->getType();
+                if ($type !== null) {
+                    $type = $this->getTypes($type);
+                }
+
+                return "$type \${$param->getName()}";
+            },
+            $params
+        );
+        $params = implode(', ', $params);
+        $return = $method->getReturnType();
+        $return = $return ? ": {$this->getTypes($return)}" : '';
+
+        return <<<EOT
+public function $name($params)$return {
+    return \$this->context->waitOne(\$this->context->callEntity(\$this->id, __METHOD__, func_get_args()));
+}
+EOT;
+    }
+
+    protected function getName(\ReflectionClass $class): string
+    {
+        return "__OrchestratorProxy_{$class->getShortName()}";
+    }
+
+    protected function impureSignal(\ReflectionMethod $method): string
+    {
+        $name = $method->getName();
+        $params = $method->getParameters();
+        $params = array_map(
+            function (\ReflectionParameter $param) {
+                $type = $param->getType();
+                if ($type !== null) {
+                    $type = $this->getTypes($type);
+                }
+
+                return "$type \${$param->getName()}";
+            },
+            $params
+        );
+        $params = implode(', ', $params);
+        $return = $method->getReturnType();
+        $return = $return ? ": {$this->getTypes($return)}" : '';
+
+        return <<<EOT
+public function $name($params)$return {
+    \$this->context->signalEntity(\$this->id, __METHOD__, func_get_args());
+}
+EOT;
+    }
+
+    protected function preamble(\ReflectionClass $class): string
+    {
+        return <<<EOT
+public function __construct(private OrchestrationContext \$context, private EntityId \$id) {}
+EOT;
+    }
+}

--- a/src/Proxy/Pure.php
+++ b/src/Proxy/Pure.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+namespace Bottledcode\DurablePhp\Proxy;
+
+/**
+ * Marks a method as pure (no side effects)
+ */
+#[\Attribute(\Attribute::TARGET_METHOD)]
+class Pure
+{
+}

--- a/tests/Feature/ClientProxyTest.php
+++ b/tests/Feature/ClientProxyTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+use Bottledcode\DurablePhp\Proxy\ClientProxy;
+use Bottledcode\DurablePhp\Proxy\Pure;
+
+if (!interface_exists(orchProxy::class)) {
+    interface orchProxy
+    {
+        public function callExample(): string;
+
+        public function signalExample(int $a): void;
+
+        #[Pure]
+        public function pureExample(int|float $number): string;
+    }
+}
+
+it('generates a proxy correctly', function () {
+    $generator = new ClientProxy();
+    $proxy = $generator->generate(orchProxy::class);
+    expect($proxy)->toBe(
+        <<<'EOT'
+
+
+class __ClientProxy_orchProxy implements orchProxy {
+  public function __construct(private mixed $source) {}
+  public function callExample(): string {
+    throw new Bottledcode\DurablePhp\Proxy\ImpureException();
+}
+public function signalExample(int $a): void {
+    throw new Bottledcode\DurablePhp\Proxy\ImpureException();
+}
+public function pureExample(int|float $number): string {
+    return $this->source->pureExample(...func_get_args());
+}
+}
+EOT
+    );
+});
+
+it('is actually callable', function () {
+    $generator = new ClientProxy();
+    $proxy = $generator->generate(orchProxy::class);
+    eval($proxy);
+    $instance = new class {
+        public function pureExample(int|float $number): string
+        {
+            return "Hello $number";
+        }
+    };
+    $proxy = new __ClientProxy_orchProxy($instance);
+    expect($proxy->pureExample(1))->toBe('Hello 1')
+        ->and(fn() => $proxy->signalExample(1))->toThrow(\Bottledcode\DurablePhp\Proxy\ImpureException::class)
+        ->and(fn() => $proxy->callExample())->toThrow(\Bottledcode\DurablePhp\Proxy\ImpureException::class);
+});

--- a/tests/Feature/OrchestratorProxyTest.php
+++ b/tests/Feature/OrchestratorProxyTest.php
@@ -1,0 +1,76 @@
+<?php
+/*
+ * Copyright ©2023 Robert Landers
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT
+ * OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+use Bottledcode\DurablePhp\Proxy\OrchestratorProxy;
+use Bottledcode\DurablePhp\Proxy\Pure;
+
+if (!interface_exists(orchProxy::class)) {
+    interface orchProxy
+    {
+        public function callExample(): string;
+
+        public function signalExample(int $a): void;
+
+        #[Pure]
+        public function pureExample(int|float $number): string;
+    }
+}
+
+it('generates a proxy correctly', function () {
+    $generator = new OrchestratorProxy();
+    $proxy = $generator->generate(orchProxy::class);
+    expect($proxy)->toBe(
+        <<<'EOT'
+
+
+class __OrchestratorProxy_orchProxy implements orchProxy {
+  public function __construct(private Bottledcode\DurablePhp\OrchestrationContextInterface $context, private Bottledcode\DurablePhp\State\EntityId $id) {}
+  public function callExample(): string {
+    return $this->context->waitOne($this->context->callEntity($this->id, __METHOD__, func_get_args()));
+}
+public function signalExample(int $a): void {
+    $this->context->signalEntity($this->id, __METHOD__, func_get_args());
+}
+public function pureExample(int|float $number): string {
+    return $this->context->waitOne($this->context->callEntity($this->id, __METHOD__, func_get_args()));
+}
+}
+EOT
+    );
+});
+
+it('actually works', function () {
+    $generator = new OrchestratorProxy();
+    eval($generator->generate(orchProxy::class));
+    $context = Mockery::mock(Bottledcode\DurablePhp\OrchestrationContextInterface::class);
+    $context->shouldReceive('waitOne')->andReturn('waited');
+    $context->shouldReceive('callEntity')->andReturn(
+        new \Bottledcode\DurablePhp\DurableFuture(new \Amp\DeferredFuture())
+    );
+    $context->shouldReceive('signalEntity')->andReturn('signal');
+    $proxy = new __OrchestratorProxy_orchProxy($context, new \Bottledcode\DurablePhp\State\EntityId('test', 'test'));
+
+    expect($proxy->callExample())->toBe('waited')
+        ->and($proxy->pureExample(1))->toBe('waited')
+        ->and($proxy->signalExample(1))->toBe(null);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -170,6 +170,8 @@ function simpleFactory(string $key, Closure|null $store = null): object
         $factory[$key] = $store;
     }
 
+    return $factory[$key]();
+
     return new class ($key, $factory[$key] ?? null) {
         public function __invoke(...$params)
         {
@@ -204,7 +206,8 @@ function getOrchestration(
     Event|null $startupEvent = null
 ): OrchestrationHistory {
     static $instance = 0;
-    simpleFactory($instance, $orchestration);
+    simpleFactory(\Bottledcode\DurablePhp\Proxy\OrchestratorProxy::class, fn() => new \Bottledcode\DurablePhp\Proxy\OrchestratorProxy());
+    simpleFactory($instance, fn() => $orchestration);
     $history = new OrchestrationHistory(
         StateId::fromInstance(new OrchestrationInstance($instance++, $id)),
         getConfig()->with(factory: 'simpleFactory')


### PR DESCRIPTION
Adds two proxy generators:

1. an `OrchestrationProxy` that can generate calls/signals and passes PHP-type-hints.
2. a `ClientProxy` that throws exceptions unless a method is marked 'Pure'.

Closes #9 