### PR TITLE
Fix entity delay spy variables

### DIFF
--- a/src/EntityContext.php
+++ b/src/EntityContext.php
@@ -154,14 +154,21 @@ class EntityContext implements EntityContextInterface
             throw new Exception('Cannot delay a function with parameters');
         }
 
-        // create the spy proxy
+        // create the spy proxy and capture the invoked operation
         $spy = $this->spyProxy->define($interfaces[0]);
+        $operationName = null;
+        $arguments = null;
         $class = new $spy($operationName, $arguments);
-        $self->bindTo($class);
+        $self = $self->bindTo($class, $class);
 
         try {
             $self();
         } catch (Throwable) {
+            // the spy always throws when an operation is invoked
+        }
+
+        if ($operationName === null || $arguments === null) {
+            throw new Exception('Did not call an operation');
         }
 
         $this->delayUntil($operationName, $arguments, $until);


### PR DESCRIPTION
## Summary
- ensure EntityContext->delay captures the operation name and arguments

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68853fa07af08333a83a07e9072401e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of delayed operations by ensuring the operation name and arguments are properly captured and validated before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->